### PR TITLE
corrected test2_17 set3.html

### DIFF
--- a/set3.html
+++ b/set3.html
@@ -304,7 +304,7 @@ Glastonbury Festival, which takes place in Somerset, England, began in 1970 and 
         test2_14: "re",
         test2_15: "ps",
         test2_16: "thing",
-        test2_17: "whelming",
+        test2_17: "elming",
         test2_18: "t",
         test2_19: "to",
         test2_20: "eps",


### PR DESCRIPTION
An Extra 'we' was present in the answer although it's already written in the text